### PR TITLE
Implemented a basic deploymodel Maven plug-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 plugins/org.franca.tools.contracts.tracegen/bin
 plugins/org.franca.tools.contracts.tracegen/traces
 plugins/org.franca.tools.contracts.tracegen/xtend-gen
+target

--- a/releng/org.franca.deploymodel.maven.plugin/.classpath
+++ b/releng/org.franca.deploymodel.maven.plugin/.classpath
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/releng/org.franca.deploymodel.maven.plugin/.project
+++ b/releng/org.franca.deploymodel.maven.plugin/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>franca-deploymodel-maven-plugin</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/releng/org.franca.deploymodel.maven.plugin/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.franca.deploymodel.maven.plugin/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding/<project>=UTF-8

--- a/releng/org.franca.deploymodel.maven.plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/releng/org.franca.deploymodel.maven.plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
+org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.5

--- a/releng/org.franca.deploymodel.maven.plugin/.settings/org.eclipse.m2e.core.prefs
+++ b/releng/org.franca.deploymodel.maven.plugin/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/releng/org.franca.deploymodel.maven.plugin/README
+++ b/releng/org.franca.deploymodel.maven.plugin/README
@@ -1,0 +1,19 @@
+To use the Franca deploymodel plug-in add the following configuration to your Maven build:
+
+<plugin>
+	<groupId>org.franca</groupId>
+	<artifactId>franca-deploymodel-maven-plugin</artifactId>
+	<version>${franca.version}</version>
+	<executions>
+		<execution>
+			<goals>
+				<goal>generate</goal>
+			</goals>
+
+			<!-- Optional. If you want/have to redirect the generator output. -->
+			<configuration>
+				<outputDirectory>${project.basedir}/src-gen</outputDirectory>
+			</configuration>
+		</execution>
+	</executions>
+</plugin>

--- a/releng/org.franca.deploymodel.maven.plugin/pom.xml
+++ b/releng/org.franca.deploymodel.maven.plugin/pom.xml
@@ -1,0 +1,106 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.franca</groupId>
+	<artifactId>franca-deploymodel-maven-plugin</artifactId>
+	<version>${franca.version}</version>
+	<packaging>maven-plugin</packaging>
+
+	<name>Franca Deploy Model Generator Maven Plugin</name>
+
+	<url>https://franca.eclipselabs.org.codespot.com</url>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<emf.version>(2.8,2.10)</emf.version>
+		<maven.version>3.0.5</maven.version>
+		<franca.version>0.10.0-SNAPSHOT</franca.version>
+		<xtext.version>2.7.3</xtext.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-core</artifactId>
+			<version>${maven.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+			<version>${maven.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugin-tools</groupId>
+			<artifactId>maven-plugin-annotations</artifactId>
+			<version>3.2</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-utils</artifactId>
+			<version>3.0.8</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.core</groupId>
+			<artifactId>org.eclipse.core.runtime</artifactId>
+			<version>3.7.0</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.emf</groupId>
+			<artifactId>org.eclipse.emf.ecore</artifactId>
+			<version>${emf.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.xtext</groupId>
+			<artifactId>org.eclipse.xtext</artifactId>
+			<version>${xtext.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.franca</groupId>
+			<artifactId>org.franca.core</artifactId>
+			<version>${franca.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.franca</groupId>
+			<artifactId>org.franca.deploymodel.dsl</artifactId>
+			<version>${franca.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.8.2</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<version>3.2</version>
+				<configuration>
+					<goalPrefix>franca-deploymodel</goalPrefix>
+					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+				</configuration>
+				<executions>
+					<execution>
+						<id>mojo-descriptor</id>
+						<goals>
+							<goal>descriptor</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>help-goal</id>
+						<goals>
+							<goal>helpmojo</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/releng/org.franca.deploymodel.maven.plugin/src/main/java/org/franca/deploymodel/maven/FrancaDeploymodelMojo.java
+++ b/releng/org.franca.deploymodel.maven.plugin/src/main/java/org/franca/deploymodel/maven/FrancaDeploymodelMojo.java
@@ -1,0 +1,193 @@
+package org.franca.deploymodel.maven;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.DirectoryScanner;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.xtext.diagnostics.Severity;
+import org.eclipse.xtext.generator.JavaIoFileSystemAccess;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.util.CancelIndicator;
+import org.eclipse.xtext.validation.CheckMode;
+import org.eclipse.xtext.validation.IResourceValidator;
+import org.eclipse.xtext.validation.Issue;
+import org.franca.deploymodel.dsl.FDeployStandaloneSetup;
+import org.franca.deploymodel.dsl.generator.FDeployGenerator;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+/**
+ * Goal which generates Franca deployment accessors from franca deployment specifications.
+ */
+@Mojo( name = "generate", defaultPhase = LifecyclePhase.GENERATE_SOURCES )
+public class FrancaDeploymodelMojo extends AbstractMojo
+{
+	/**
+	 * Get access to the Maven project.
+	 */
+	@Parameter(defaultValue = "${project}", required = true)
+	private MavenProject project;
+
+	/**
+	 * If set to true then Maven will print "path: compiling" for each root directory
+	 * or files that are processed.
+	 */
+	@Parameter(defaultValue = "true", property = "notifyCompilation", required = true)
+	private boolean notifyCompilation;
+
+	/**
+	 * Location of the base output directory to generate to.
+	 */
+	@Parameter(defaultValue = "${project.build.directory}", property = "outputDir", required = true)
+	private File outputDirectory;
+
+	/**
+	 * Set an include filter for source files.
+	 * 
+	 * If empty a default filter for Franca deployment files will be used.
+	 */
+	@Parameter(defaultValue = "", property = "includes", required = true)
+	private Set<String> includes;
+
+	/**
+	 * Set an exclude filter for source files.
+	 */
+	@Parameter(defaultValue = "", property = "excludes", required = true)
+	private Set<String> excludes;
+
+
+	@Inject
+	private Provider<ResourceSet> resourceSetProvider;
+
+	@Inject
+	private FDeployGenerator generator;
+
+	@Inject
+	private JavaIoFileSystemAccess fileSystemAccess;
+
+
+	public void execute() throws MojoExecutionException
+	{
+		getLog().debug("Using output directory " + outputDirectory.getAbsolutePath());
+
+		// Collect the source directories to search Franca deployment files in.
+		List<File> sourceDirs = getSourceRoots(project.getCompileSourceRoots());
+
+		// Create the output directory if required.
+		if (!outputDirectory.exists()) {
+			getLog().debug("Creating output directory " + outputDirectory.getAbsolutePath());
+			outputDirectory.mkdirs();
+		}
+
+		// Add the output directory to the project's source directories so that the generated
+		// files are compiled by the Java compiler.
+		project.addCompileSourceRoot(outputDirectory.getAbsolutePath());
+
+		// Find Franca deployment files to process.
+		List<File> fdeplFiles = findFdeplFiles(sourceDirs);
+
+		// Generate Franca deployment accessors.
+		if (!fdeplFiles.isEmpty()) {
+			generate(fdeplFiles);
+		}
+	}
+
+	private List<File> findFdeplFiles(List<File> sourceDirs) {
+		DirectoryScanner scanner = new DirectoryScanner();
+		if (includes.isEmpty()) {
+			includes.add("**/*.fdepl");
+		}
+		scanner.setIncludes(includes.toArray(new String[includes.size()]));
+		if (!excludes.isEmpty()) {
+			scanner.setExcludes(excludes.toArray(new String[excludes.size()]));
+		}
+
+		List<File> fdeplFiles = new ArrayList<File>();
+		for (File sourceDirectory: sourceDirs) {
+			if (sourceDirectory.isDirectory()) {
+				scanner.setBasedir(sourceDirectory);
+				scanner.scan();
+				for (String file: scanner.getIncludedFiles()) {
+					File fdepl = new File(sourceDirectory, file);
+					fdeplFiles.add(fdepl);
+					getLog().debug("Found Franca deployment file " + fdepl.getAbsolutePath());
+				}
+			}
+		}
+
+		return fdeplFiles;
+	}
+
+	private void generate(List<File> fdeplFiles) throws MojoExecutionException {
+		getLog().info("Generating Franca deployment accessors for " + fdeplFiles.size() + " files.");
+		new FDeployStandaloneSetup().createInjectorAndDoEMFRegistration().injectMembers(this);
+		for (File fdepl: fdeplFiles) {
+			generate(fdepl, outputDirectory);
+		}
+	}
+
+	private void generate(File fdepl, File outputDirectory) throws MojoExecutionException {
+		// Load the Franca deployment model
+		ResourceSet resourceSet = resourceSetProvider.get();
+		Resource fdeplResource = resourceSet.getResource(URI.createFileURI(fdepl.getAbsolutePath()), true);
+
+		// Validate the Franca deployment model
+		IResourceValidator fModelValidator =
+				((XtextResource) fdeplResource)
+				.getResourceServiceProvider()
+				.getResourceValidator();
+
+		List<Issue> issues = fModelValidator.validate(fdeplResource, CheckMode.ALL, CancelIndicator.NullImpl);
+
+		boolean hasErrors = false;
+		StringBuilder errorString = new StringBuilder();
+		for (Issue issue : issues) {
+			if (issue.getSeverity() == Severity.ERROR) {
+				errorString.append(issue.toString());
+				hasErrors = true;
+			}
+			getLog().error(issue.toString());
+		}
+
+		// Abort the build on validation errors.
+		if (hasErrors) {
+			throw new MojoExecutionException(errorString.toString());
+		}
+
+		// Generate the Franca deployment accessor classes.
+		getLog().debug("Generating deployment accessors for " + fdepl.getAbsolutePath());
+		fileSystemAccess.setOutputPath(outputDirectory.getAbsolutePath());
+		generator.doGenerate(fdeplResource, fileSystemAccess);
+	}
+
+	private List<File> getSourceRoots(List<String> projectSourceRoots) {
+		List<File> sourceRoots = new ArrayList<File>();
+		for (String sourceRootStr: projectSourceRoots) {
+			File sourceRoot = new File(sourceRootStr);
+			if (sourceRoot.equals(outputDirectory)) {
+				getLog().debug("Skipping output directory " + sourceRootStr);
+			}
+			else if (sourceRoot.isDirectory()) {
+				getLog().debug("Using source directory " + sourceRootStr);
+				sourceRoots.add(sourceRoot);
+			}
+			else {
+				getLog().info("Skipping non existent source directory " + sourceRootStr);
+			}
+		}
+
+		return sourceRoots;
+	}
+}

--- a/releng/org.franca.deploymodel.maven.plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/releng/org.franca.deploymodel.maven.plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,14 @@
+<lifecycleMappingMetadata>
+	<pluginExecutions>
+		<pluginExecution>
+			<pluginExecutionFilter>
+				<goals>
+					<goal>generate</goal>
+				</goals>
+			</pluginExecutionFilter>
+			<action>
+				<ignore />
+			</action>
+		</pluginExecution>
+	</pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
Implemented a basic Maven plug-in that runs the FDeployGenerator in
order to have the deployment accessors for a Franca deployment
specification generated on-the-fly during a Maven build.

This should fix issue #186, though further improvements might be required depending on the intended use.