### PR TITLE
Improve VIM highlighting

### DIFF
--- a/misc/vim-highlight/fidl.vim
+++ b/misc/vim-highlight/fidl.vim
@@ -1,9 +1,10 @@
 " Vim syntax file
 " Language:    	   	FIDL (FRANCA Interface Description Language)
 " Maintainer:  	   	Gabriel Almeida <gabrielmarchesan AT gmail DOT com>
-" Latest Revision:   	Tue Jun 30 2015 
+" Latest Revision:   	Sat Jun 18 2016
 " History:
-" 0.1 (2015-06-30): Gabriel Almeida - first proposal  
+" 0.1 (2015-06-30): Gabriel Almeida - first proposal
+" 0.2 (2016-06-18): Oleksandr Kravchuk - cleanups and small improvements
 
 " For version 5.x: Clear all syntax items
 " For version 6.x: Quit when a syntax file was already loaded
@@ -30,22 +31,22 @@ else
 endif
 
 " Keywords codelanguage-def[Franca]
-syn keyword fConstant 			version major minor const skipwhite
-syn keyword fBoolean 			true false skipwhite
-syn keyword fType           		Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64 Boolean String Float Double ByteBuffe skipwhite
-syn keyword fStructure      		struct union enumeration typedef skipwhite
+syn keyword fBoolean             true false  skipwhite
+syn keyword fType                Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64 Boolean String Float Double ByteBuffe  skipwhite
+syn keyword fStructure           struct union enumeration typedef  skipwhite
 
 syn keyword syntaxElementKeyword typeCollection interface attribute method broadcast in out error  skipempty skipwhite 
 syn keyword syntaxElementKeyword readonly noSubscriptions fireAndForget selective manages array of  skipempty skipwhite
 syn keyword syntaxElementKeyword is map to extends polymorphic  skipempty skipwhite
 syn keyword syntaxElementKeyword contract PSM vars state transition initial call respond signal set update  skipempty skipwhite
+syn keyword syntaxElementKeyword version major minor const  skipempty skipwhite
 
 " Keywords codelanguage-def[FDeploy]
-syn keyword syntaxElementKeyword import specification extends for optional default providers instances interfaces  skipempty skipwhite
+syn keyword syntaxElementKeyword import from specification extends for optional default providers instances interfaces  skipempty skipwhite
 syn keyword syntaxElementKeyword type_collections attributes methods broadcasts arguments structs struct_fields  skipempty skipwhite
 syn keyword syntaxElementKeyword unions union_fields arrays enumerations enumerators strings numbers integers floats  skipempty skipwhite
 syn keyword syntaxElementKeyword Boolean Integer String Interface define provider instance interface attribute method  skipempty skipwhite
-syn keyword syntaxElementKeyword broadcast in out array struct enumeration false true skipempty skipwhite
+syn keyword syntaxElementKeyword broadcast in out array struct enumeration false true  skipempty skipwhite
 
 " Keywords codelanguage-def[Xtend]
 syn keyword syntaxElementKeyword abstract continue def override for new switch assert default goto package synchronized  skipempty skipwhite
@@ -54,8 +55,7 @@ syn keyword syntaxElementKeyword public throws case enum instanceof return catch
 syn keyword syntaxElementKeyword void class finally long float super while create dispatch extension typeof as val var  skipempty skipwhite
 syn keyword syntaxElementKeyword true false null IF ELSE ELSEIF ENDIF FOR ENDFOR BEFORE AFTER SEPARATOR  skipempty skipwhite
 
-
-syn keyword     fTodo           contained TODO FIXME XXX
+syn keyword fTodo      contained TODO FIXME XXX NOTE
 
 hi def link fConstant 	Constant
 hi def link fBoolean 	Boolean
@@ -65,6 +65,4 @@ hi def link fStructure  Structure
 hi def link syntaxElementKeyword Keyword
 
 let b:current_syntax = "fidl"
-
-" vim: ts=8
 


### PR DESCRIPTION
Fixed file formatting and improved highlighting rules:
- cleaned up syntax
- removed whitespaces
- added highlighting for 'NOTE' keyword in comments
- added highlighting for 'from', 'version', 'major', 'minor',
  and 'const' keywords