### PR TITLE
Fixed example in deployment of interface providers

### DIFF
--- a/docs/org.franca.userguide/src/210-DeploymentModels.xdoc
+++ b/docs/org.franca.userguide/src/210-DeploymentModels.xdoc
@@ -682,7 +682,7 @@ code[FDeploy][
 import "deployspecs/SampleDeploySpec.fdepl"
 import "../franca/demo1.fidl"
 
-define SampleDeploySpec for provider ExampleServer {
+define SampleDeploySpec for provider as ExampleServer {
 	ProcessName = "server1.exe"
 	
 	instance org.franca.examples.demo.PlayerAPI {


### PR DESCRIPTION
Because of the new extension point concept introduced with Franca 0.13 the deployment of interface providers changes slightly. The example in the `Deployment of interface providers` section still uses the old syntax.