### PR TITLE
fixed build problems

### DIFF
--- a/releng/org.franca.deploymodel.maven.plugin/pom.xml
+++ b/releng/org.franca.deploymodel.maven.plugin/pom.xml
@@ -58,6 +58,11 @@
 			<version>${emf.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.emf</groupId>
+			<artifactId>org.eclipse.emf.ecore.xmi</artifactId>
+			<version>${emf.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.xtext</groupId>
 			<artifactId>org.eclipse.xtext</artifactId>
 			<version>${xtext.version}</version>

--- a/releng/org.franca.parent/pom.xml
+++ b/releng/org.franca.parent/pom.xml
@@ -442,9 +442,24 @@
 					<!-- workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=536445 -->
 					<dependencies>
 						<dependency>
-							<groupId>org.eclipse.platform</groupId>
-							<artifactId>org.eclipse.equinox.common</artifactId>
-							<version>3.10.0</version>
+							<groupId>org.eclipse.jdt</groupId>
+							<artifactId>org.eclipse.jdt.core</artifactId>
+							<version>3.13.102</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.jdt</groupId>
+							<artifactId>org.eclipse.jdt.compiler.apt</artifactId>
+							<version>1.3.110</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.jdt</groupId>
+							<artifactId>org.eclipse.jdt.compiler.tool</artifactId>
+							<version>1.2.101</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.emf</groupId>
+							<artifactId>org.eclipse.emf.codegen</artifactId>
+							<version>2.11.0</version>
 						</dependency>
 					</dependencies>
 					<!-- end workaround -->

--- a/releng/org.franca.targetplatform/franca-neon.target
+++ b/releng/org.franca.targetplatform/franca-neon.target
@@ -67,7 +67,7 @@
       <repository location="http://www.xpect-tests.org/updatesite/nightly/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.eclemma.feature.feature.group" version="3.1.0.201805281015"/>
+      <unit id="org.eclipse.eclemma.feature.feature.group" version="3.1.1.201809121651"/>
       <repository location="http://update.eclemma.org/"/>
     </location>
   </locations>


### PR DESCRIPTION
fixed build problems
- xtend-maven-plugin needs different workaround https://github.com/eclipse/xtext/issues/1373
- new eclemma version on update site, older no longer available

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>