### PR TITLE
Remove a workaround comment exists in plugins/org.franca.help/pom.xml file since the related issue had been already fixed.

### DIFF
--- a/plugins/org.franca.help/pom.xml
+++ b/plugins/org.franca.help/pom.xml
@@ -35,7 +35,6 @@
 								<goals>
 									<goal>javadoc</goal>
 								</goals>
-						<!-- Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=453601 -->
 						<phase>verify</phase>
 						<configuration>
 						<buildDirectory>${project.build.directory}</buildDirectory>


### PR DESCRIPTION
I think the fix of https://bugs.eclipse.org/bugs/show_bug.cgi?id=453601 had been already applied to the associated part, but the comment still exists. The comment could be removed.

The comment: https://github.com/franca/franca/blob/b97df35a006e90d0a29ec602c01c24e8a045803a/plugins/org.franca.help/pom.xml#L38