### PR TITLE
Update README.md : Fixing broken link for user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Franca forum at Google Groups, see http://groups.google.com/group/franca-framewo
 
 ## Misc
 
-There is an [online Franca presentation](https://projects.itemis.de/html/web-presentations/kbi/std/franca_std/) available.
+There is an [online Franca user guide](https://info.itemis.com/en/franca-user-guide) available.
 This can also be used nicely from smartphones and tablets.
 
 The Franca framework has been built using the open source projects [EMF](http://www.eclipse.org/emf),


### PR DESCRIPTION
Franca user guide link provided is broken (https://projects.itemis.de/html/web-presentations/kbi/std/franca_std/) and is now available as a downloadable pdf via the updated link.

Fixing this to redirect to the right link.